### PR TITLE
Fix mock configuration and simplify RestClient

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,24 @@
 # demo-mock-api-test
+
+This project demonstrates how to call a mock server from a Spring Boot
+application using `RestClient`. The WireMock server is configured via
+Docker Compose and listens on port `8081` by default.
+
+## Running
+
+Build the bridge API and start the services:
+
+```bash
+./mvnw package
+docker compose up
+```
+
+Send a request to the bridge API:
+
+```bash
+curl -X POST -H 'Content-Type: application/json' \
+  -d '{"name":"田中"}' http://localhost:8082/bridge
+```
+
+The application will forward the request to WireMock and return the mock
+response defined in `wiremock/mappings/humans-name-mapping.json`.

--- a/bridge-api/src/main/java/com/yuzukiku/bridgeapi/infrastruture/MockServerClient.java
+++ b/bridge-api/src/main/java/com/yuzukiku/bridgeapi/infrastruture/MockServerClient.java
@@ -1,6 +1,5 @@
 package com.yuzukiku.bridgeapi.infrastruture;
 
-import com.yuzukiku.bridgeapi.config.MockServerProperties;
 import com.yuzukiku.bridgeapi.presentation.dto.UserRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
@@ -11,13 +10,12 @@ import org.springframework.web.client.RestClient;
 @RequiredArgsConstructor
 public class MockServerClient {
     private final RestClient.Builder restClientBuilder;
-    private final MockServerProperties properties;
 
     public MockUserResponse fetchUserData(UserRequest request) {
         return restClientBuilder
                 .build()
                 .post()
-                .uri(properties.getUrl() + "/humans/name")
+                .uri("/humans/name")
                 .contentType(MediaType.APPLICATION_JSON)
                 .body(request)
                 .retrieve()

--- a/wiremock/mappings/humans-name-mapping.json
+++ b/wiremock/mappings/humans-name-mapping.json
@@ -4,7 +4,7 @@
     "url": "/humans/name",
     "bodyPatterns": [
       {
-        "matchesJsonPath": "$[?(@.name == 'Ken Watanabe')]"
+        "matchesJsonPath": "$[?(@.name == '田中')]"
       }
     ]
   },
@@ -13,6 +13,6 @@
     "headers": {
       "Content-Type": "application/json"
     },
-    "body": "[{\"id\":\"123e4567-e89b-12d3-a456-426614174000\",\"name\":\"Ken Watanabe\",\"age\":40,\"hobbies\":[\"gardening\"]}]"
+    "body": "[{\"id\":\"123e4567-e89b-12d3-a456-426614174000\",\"name\":\"田中\",\"age\":25,\"hobbies\":[\"読書\"]}]"
   }
 }


### PR DESCRIPTION
## Summary
- correct the RestClient client implementation
- update WireMock mapping to respond to `田中`
- document how to run the demo

## Testing
- `./mvnw test -q` *(fails: Failed to fetch https://repo.maven.apache.org/...)*

------
https://chatgpt.com/codex/tasks/task_e_687f52e3f2c483279dfe347812b79854