### PR TITLE
Fix package path to infrastructure

### DIFF
--- a/bridge-api/src/main/java/com/yuzukiku/bridgeapi/application/UserService.java
+++ b/bridge-api/src/main/java/com/yuzukiku/bridgeapi/application/UserService.java
@@ -1,7 +1,7 @@
 package com.yuzukiku.bridgeapi.application;
 
-import com.yuzukiku.bridgeapi.infrastruture.MockServerClient;
-import com.yuzukiku.bridgeapi.infrastruture.MockUserResponse;
+import com.yuzukiku.bridgeapi.infrastructure.MockServerClient;
+import com.yuzukiku.bridgeapi.infrastructure.MockUserResponse;
 import com.yuzukiku.bridgeapi.presentation.dto.UserRequest;
 import com.yuzukiku.bridgeapi.presentation.dto.UserResponse;
 import lombok.RequiredArgsConstructor;

--- a/bridge-api/src/main/java/com/yuzukiku/bridgeapi/infrastructure/MockServerClient.java
+++ b/bridge-api/src/main/java/com/yuzukiku/bridgeapi/infrastructure/MockServerClient.java
@@ -1,4 +1,4 @@
-package com.yuzukiku.bridgeapi.infrastruture;
+package com.yuzukiku.bridgeapi.infrastructure;
 
 import com.yuzukiku.bridgeapi.presentation.dto.UserRequest;
 import lombok.RequiredArgsConstructor;

--- a/bridge-api/src/main/java/com/yuzukiku/bridgeapi/infrastructure/MockUserResponse.java
+++ b/bridge-api/src/main/java/com/yuzukiku/bridgeapi/infrastructure/MockUserResponse.java
@@ -1,4 +1,4 @@
-package com.yuzukiku.bridgeapi.infrastruture;
+package com.yuzukiku.bridgeapi.infrastructure;
 
 import lombok.Data;
 

--- a/bridge-api/src/test/java/com/yuzukiku/bridgeapi/MockServerClientTest.java
+++ b/bridge-api/src/test/java/com/yuzukiku/bridgeapi/MockServerClientTest.java
@@ -1,8 +1,8 @@
 package com.yuzukiku.bridgeapi;
 
 import com.yuzukiku.bridgeapi.config.RestClientConfig;
-import com.yuzukiku.bridgeapi.infrastruture.MockServerClient;
-import com.yuzukiku.bridgeapi.infrastruture.MockUserResponse;
+import com.yuzukiku.bridgeapi.infrastructure.MockServerClient;
+import com.yuzukiku.bridgeapi.infrastructure.MockUserResponse;
 import com.yuzukiku.bridgeapi.presentation.dto.UserRequest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;


### PR DESCRIPTION
## Summary
- rename directory `infrastruture` to `infrastructure`
- update package declarations in `MockServerClient` and `MockUserResponse`
- adjust imports in `UserService` and tests

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6881bd312f3083278d97450703f514ff