### PR TITLE
Fix Wiremock volume

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -20,5 +20,4 @@ services:
       - "8080:8080"
     volumes:
       - ./wiremock/mappings:/home/wiremock/mappings
-      - ./wiremock/__files:/home/wiremock/__files
 


### PR DESCRIPTION
## Summary
- Remove the wiremock __files volume from compose file

## Testing
- `./mvnw test` *(fails: could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6881c2a31b288327b1848e686e32163f